### PR TITLE
metasm/os/linux.rb: ArgumentError fails with can't convert Array into Integer (TypeError)

### DIFF
--- a/metasm/os/linux.rb
+++ b/metasm/os/linux.rb
@@ -1060,7 +1060,7 @@ class LinDebugger < Debugger
 		begin
 			pid = Integer(pidpath)
 			attach(pid)
-		rescue ArgumentError
+		rescue TypeError
 			create_process(pidpath)
 		end
 	end


### PR DESCRIPTION
When instantiating a debugger on Linux with a path of an executable rather than a PID to attach to, the following error occurs:

 metasm/os/linux.rb:1061:in `Integer': can't convert Array into Integer (TypeError)
    from metasm/metasm/os/linux.rb:1061:in`initialize'
    from metasm/metasm/os/linux.rb:665:in `new'
    from metasm/metasm/os/linux.rb:665:in`create_debugger'
    from autoex.rb:19:in `block in <main>'
    from autoex.rb:18:in`loop'
    from autoex.rb:18:in `<main>'

The fix changes ArgumentError to TypeError.
