### PR TITLE
Get the underlying C struct for a Windows thread context

### DIFF
--- a/metasm/os/windows.rb
+++ b/metasm/os/windows.rb
@@ -1423,6 +1423,11 @@ class WinOS < OS
 				end
 			end
 
+			# retrieve the actual context structure (so we can pass to API's like StackWalk64)
+			def c_struct
+				@context
+			end
+			
 			# update the context to reflect the current thread reg values
 			# call only when the thread is suspended
 			def update


### PR DESCRIPTION
Hi, I needed to pass a debugged threads context structure  (_CONTEXT_AMD64 or _CONTEXT_I386) to dbghelp!StackWalk64 (via the winapi dynldr) so added a helper method to retrieve the structure.
