### PR TITLE
Coerce Rational to Integer in X86_64 c compiler to allow usage of & operator.

### DIFF
--- a/metasm/cpu/x86_64/compile_c.rb
+++ b/metasm/cpu/x86_64/compile_c.rb
@@ -982,7 +982,7 @@ class CCompiler < C::Compiler
 		@state.dirty -= @state.abi_trashregs
 		if localspc
 			localspc = (localspc + 7) / 8 * 8
-			if @state.args_space > 0 and (localspc/8 + @state.dirty.length) & 1 == 1
+			if @state.args_space > 0 and (localspc/8 + @state.dirty.length).to_i & 1 == 1
 				# ensure 16-o stack align on windows
 				localspc += 8
 			end


### PR DESCRIPTION
I'm not entirely sure how to reproduce this in a minimal way, but sometimes the the expr `(localspc/8 + @state.dirty.length)` ends up being an instance of Rational (part of Ruby stdlib), which does not have the `&` operator defined. This works around the issue by forcing the Rational back to an Integer.

If you want the C source code I was using to trigger this error, send me an email (joev@metasploit.com) and I'll send it over to you.
