### PR TITLE
Fix save file dialog in dasm gui. Fix multiple typos

### DIFF
--- a/doc/code_organisation.txt
+++ b/doc/code_organisation.txt
@@ -107,7 +107,7 @@ The actual implementation of the GUI are found in:
 
 Please note that the Qt backend does not work *at all*.
 
-The `gui.rb` file in the main directory is used to chose among the available GUI backend
+The `gui.rb` file in the main directory is used to choose among the available GUI backend
 the most appropriate for the current session.
 
 

--- a/metasm/encode.rb
+++ b/metasm/encode.rb
@@ -42,7 +42,7 @@ class ExeFormat
 		edata
 	end
 
-	# chose among multiple possible sub-EncodedData
+	# choose among multiple possible sub-EncodedData
 	# assumes all ambiguous edata have the equivallent relocations in the same order
 	def assemble_resolve(ary)
 		startlabel = new_label('section_start')
@@ -167,7 +167,7 @@ class ExeFormat
 		# for linear expressions of internal variables (ie differences of labels from the ary):
 		#  - calc target numeric bounds, and reject relocs not accepting worst case value
 		#  - else reject all but largest place available
-		# then chose the shortest overall EData left
+		# then choose the shortest overall EData left
 		ary.map! { |elem|
 			case elem
 			when Array

--- a/metasm/gui/dasm_main.rb
+++ b/metasm/gui/dasm_main.rb
@@ -946,11 +946,11 @@ class DasmWindow < Window
 		exe
 	end
 
-	def promptopen(caption='chose target binary', &b)
+	def promptopen(caption='choose target binary', &b)
 		openfile(caption) { |exename| loadfile(exename) ; b.call(self) if b }
 	end
 
-	def promptdebug(caption='chose target', &b)
+	def promptdebug(caption='choose target', &b)
 		l = nil
 		i = inputbox(caption) { |name|
 			i = nil ; l.destroy if l and not l.destroyed?
@@ -996,7 +996,7 @@ class DasmWindow < Window
 			@dasm_widget.dasm.save_file @savefile
 			return
 		end
-		openfile('chose save file') { |file|
+		savefile('choose save file') { |file|
 			@savefile = file
 			@dasm_widget.dasm.save_file(file)
 		}
@@ -1039,13 +1039,13 @@ class DasmWindow < Window
 
 		importmenu = new_menu
 		addsubmenu(importmenu, 'Load _map') {
-			openfile('chose map file') { |file|
+			openfile('choose map file') { |file|
 				@dasm_widget.dasm.load_map(File.read(file)) if @dasm_widget
 				@dasm_widget.gui_update if @dasm_widget
 			} if @dasm_widget
 		}
 		addsubmenu(importmenu, 'Load _C') {
-			openfile('chose C file') { |file|
+			openfile('choose C file') { |file|
 				@dasm_widget.dasm.parse_c(File.read(file)) if @dasm_widget
 			} if @dasm_widget
 		}
@@ -1053,21 +1053,21 @@ class DasmWindow < Window
 
 		exportmenu = new_menu
 		addsubmenu(exportmenu, 'Save _map') {
-			savefile('chose map file') { |file|
+			savefile('choose map file') { |file|
 				File.open(file, 'w') { |fd|
 					fd.puts @dasm_widget.dasm.save_map
 				} if @dasm_widget
 			} if @dasm_widget
 		}
 		addsubmenu(exportmenu, 'Save _asm') {
-			savefile('chose asm file') { |file|
+			savefile('choose asm file') { |file|
 				File.open(file, 'w') { |fd|
 					fd.puts @dasm_widget.dasm
 				} if @dasm_widget
 			} if @dasm_widget
 		}
 		addsubmenu(exportmenu, 'Save _C') {
-			savefile('chose C file') { |file|
+			savefile('choose C file') { |file|
 				File.open(file, 'w') { |fd|
 					fd.puts @dasm_widget.dasm.c_parser
 				} if @dasm_widget

--- a/metasm/gui/debug.rb
+++ b/metasm/gui/debug.rb
@@ -154,7 +154,7 @@ class DbgWidget < ContainerVBoxWidget
 		@children.each { |c| c.gui_update }
 	end
 
-	def prompt_attach(caption='chose target')
+	def prompt_attach(caption='choose target')
 		l = nil
 		i = inputbox(caption) { |name|
 			i = nil ; l.destroy if l and not l.destroyed?
@@ -184,7 +184,7 @@ class DbgWidget < ContainerVBoxWidget
 		} if not list_pr.empty?
 	end
 
-	def prompt_createprocess(caption='chose path')
+	def prompt_createprocess(caption='choose path')
 		openfile(caption) { |path|
 			path = '"' + path + '"' if @dbg.shortname == 'windbg' and path =~ /\s/
 			inputbox('target args?', :text => path) { |pa|

--- a/metasm/gui/gtk.rb
+++ b/metasm/gui/gtk.rb
@@ -45,7 +45,7 @@ module Msgbox
 		InputBox.new(toplevel, *a) { |*ya| protect { yield(*ya) } }
 	end
 
-	# asks to chose a file to open, yields filename
+	# asks to choose a file to open, yields filename
 	# args: title, :path => path
 	def openfile(*a)
 		OpenFile.new(toplevel, *a) { |*ya| protect { yield(*ya) } }

--- a/metasm/gui/qt.rb
+++ b/metasm/gui/qt.rb
@@ -51,7 +51,7 @@ module Msgbox
 
 	@@dialogfilefolder = nil
 
-	# asks to chose a file to open, yields filename
+	# asks to choose a file to open, yields filename
 	# args: title, :path => path
 	def openfile(title, opts={})
 		f = Qt::FileDialog.get_open_file_name(nil, title, @@dialogfilefolder)

--- a/metasm/gui/win32.rb
+++ b/metasm/gui/win32.rb
@@ -1401,7 +1401,7 @@ module Msgbox
 		InputBox.new(toplevel, *a) { |*ya| protect { yield(*ya) } }
 	end
 
-	# asks to chose a file to open, yields filename
+	# asks to choose a file to open, yields filename
 	# args: title, :path => path
 	def openfile(*a)
 		OpenFile.new(toplevel, *a) { |*ya| protect { yield(*ya) } }

--- a/samples/dasm-plugins/bindiff.rb
+++ b/samples/dasm-plugins/bindiff.rb
@@ -8,7 +8,7 @@
 
 require File.join(Metasm::Metasmdir, 'samples', 'bindiff.rb')
 
-Gui::DasmWindow.new("bindiff target").promptopen("chose bindiff target") { |w|
+Gui::DasmWindow.new("bindiff target").promptopen("choose bindiff target") { |w|
 	w.title = "#{w.widget.dasm.program.filename} - metasm bindiff"
 	@bindiff_win = BinDiffWindow.new(self, w.widget.dasm)
 }


### PR DESCRIPTION
**Fix save file dialog in dasm gui**
When using samples/disassemble-gui.rb, if you try to save your session, an "open file" dialog is shown. This fix makes the gui to show a "save file" dialog.

 **Fix multiple typos**
Basically, s/chose/choose/. I feel the word "choose" fits better in those case (Disclaimer: I'm not an english native speaker :)