### PR TITLE
fix syntax errors from recent ruby version

### DIFF
--- a/metasm/cpu/st20/decompile.rb
+++ b/metasm/cpu/st20/decompile.rb
@@ -181,7 +181,7 @@ class ST20
 					# conditional jump
 					commit[]
 					n = dcmp.backtrace_target(get_xrefs_x(dcmp.dasm, di).first, di.address)
-					cc = ceb[:a, :!=, 0]
+					cc = ceb[:a, :'!=', 0]
 					# XXX switch/indirect/multiple jmp
 					stmts << C::If.new(C::CExpression[cc], C::Goto.new(n))
 					to.delete dcmp.dasm.normalize(n)

--- a/metasm/gui/dasm_hex.rb
+++ b/metasm/gui/dasm_hex.rb
@@ -350,8 +350,8 @@ class HexWidget < DrawableWidget
 				else
 					case v = key
 					when ?0..?9; v -= ?0
-					when ?a..?f; v -= ?a-10
-					when ?A..?F; v -= ?A-10
+					when ?a..?f; v -= ?a - 10
+					when ?A..?F; v -= ?A - 10
 					else return false
 					end
 				end

--- a/metasm/gui/debug.rb
+++ b/metasm/gui/debug.rb
@@ -410,8 +410,8 @@ class DbgRegWidget < DrawableWidget
 				case v = key
 				when ?\x20; v = nil
 				when ?0..?9; v -= ?0
-				when ?a..?f; v -= ?a-10
-				when ?A..?F; v -= ?A-10
+				when ?a..?f; v -= ?a - 10
+				when ?A..?F; v -= ?A - 10
 				else return false
 				end
 			end


### PR DESCRIPTION
Fixed a few places where recent ruby versions were interpreting "-" as part of an identifier instead of a subtraction operator by adding spaces.