### PR TITLE
on the recent debian distro, the package named ruby-gtk2.

### DIFF
--- a/metasm/gui.rb
+++ b/metasm/gui.rb
@@ -6,7 +6,7 @@ backend = ENV['METASM_GUI'] || (
 			require 'gtk2'
 			'gtk'
 		rescue LoadError
-			raise LoadError, 'No GUI ruby binding installed - please install libgtk2-ruby'
+			raise LoadError, 'No GUI ruby binding installed - please install ruby-gtk2'
 		end
 	end
 )


### PR DESCRIPTION
Hello @jjyg ,

Here a trivial path to change for this error message on the dependency missing on the recent debian like distro.

Regards,