### PR TITLE
Add test-unit dependency to the gemspec

### DIFF
--- a/metasm.gemspec
+++ b/metasm.gemspec
@@ -18,5 +18,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "bundler", "~> 1.7"
   s.add_development_dependency "rake"
+  s.add_development_dependency "test-unit"
 end
 


### PR DESCRIPTION
test-unit has been missing from the standard library since 2.2. It is impossible to run the tests if it is not installed:
```
cannot load such file -- test/unit (LoadError)
```