### PR TITLE
Add gem source to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,1 +1,3 @@
-gemspec
+source 'https://rubygems.org' do
+  gemspec
+end


### PR DESCRIPTION
Gemfiles require at least one gem source, in the form of the URL for a
RubyGems server (https://bundler.io/gemfile.html).