### PR TITLE
Fix the usage of Disassembler's @addrs_todo

### DIFF
--- a/metasm/disassemble_api.rb
+++ b/metasm/disassemble_api.rb
@@ -271,7 +271,7 @@ class Disassembler
 		if b = block_at(from_addr)
 			b.add_to_normal(addr)
 		end
-		@addrs_todo << [addr, from_addr]
+		@addrs_todo << { :addr => addr, :from => from_addr }
 		disassemble
 	end
 

--- a/metasm/exe_format/pe.rb
+++ b/metasm/exe_format/pe.rb
@@ -227,7 +227,7 @@ EOS
 			a.each { |aa|
 				next if aa == Expression::Unknown
 				dasm.auto_label_at(aa, 'seh', 'loc', 'sub')
-				dasm.addrs_todo << [aa]
+				dasm.addrs_todo << { :addr => aa }
 			}
 			super(dasm, di)
 		else

--- a/samples/dasm-plugins/selfmodify.rb
+++ b/samples/dasm-plugins/selfmodify.rb
@@ -115,11 +115,11 @@ def self.emu(dasm, addr)
 	loop do
 		# the effects of the loop
 		post_bd = loop_bd.inject({}) { |bd, (k, v)|
-	       		if k.kind_of? Metasm::Indirection
+			if k.kind_of? Metasm::Indirection
 				k = k.bind(pre_bd).reduce_rec
 				raise "bad ptr #{k}" if not dasm.get_section_at(k.pointer.reduce)
 			end
-		       	bd.update k => Metasm::Expression[v.bind(pre_bd).reduce]
+			bd.update k => Metasm::Expression[v.bind(pre_bd).reduce]
 		}
 
 		# the indirections used by the loop

--- a/samples/dasm-plugins/selfmodify.rb
+++ b/samples/dasm-plugins/selfmodify.rb
@@ -179,7 +179,7 @@ def self.redirect(dasm, addr)
 		b.to_normal.map! { |tn| dasm.normalize(tn) == addr ? newto : tn }
 		dasm.add_xref(newto, Metasm::Xref.new(:x, b.list.last.address))
 		b.list.last.add_comment "x:#{newto}"
-		dasm.addrs_todo << [newto, b.list.last.address]
+		dasm.addrs_todo << { :addr => newto, :from => b.list.last.address }
 	}
 end
 end


### PR DESCRIPTION
@addrs_todo is an array of Hashes, but in some places the appended objects are Arrays.