### PR TITLE
samples/disassemble-gui: fix disassemble

### DIFF
--- a/samples/disassemble-gui.rb
+++ b/samples/disassemble-gui.rb
@@ -120,7 +120,7 @@ if dasm
 		if opts[:fast]
 			w.dasm_widget.disassemble_fast_deep(eep)
 		else
-			w.disassemble(eep)
+			w.dasm_widget.disassemble(eep)
 		end
 	}
 


### PR DESCRIPTION
Fix error `undefined method 'disassemble' for #<Metasm::Gui::DasmWindow:...>` when passing a entrypoint to samples/disassemble-gui.rb.

Looks like this was introduced by 6cddb1aa5583337072c45bd43833e377308a1449.