### PR TITLE
gui/hex: fix hex view when section's base is a String

### DIFF
--- a/metasm/gui/dasm_hex.rb
+++ b/metasm/gui/dasm_hex.rb
@@ -27,7 +27,7 @@ class HexWidget < DrawableWidget
 		@oldcaret_x_data = 42
 		@focus_zone = @oldfocus_zone = :hex
 		@addr_min = @dasm.sections.keys.grep(Integer).min rescue nil
-		@addr_max = @dasm.sections.map { |s, e| s + e.length }.max rescue nil
+		@addr_max = @dasm.sections.select { |s, _| s.kind_of?(Integer) }.map { |s, e| s + e.length }.max rescue nil
 		@view_addr = @dasm.prog_binding['entrypoint'] || @addr_min || 0
 		@show_address = @show_data = @show_ascii = true
 		@data_size = 1
@@ -538,7 +538,7 @@ class HexWidget < DrawableWidget
 
 	def gui_update
 		@addr_min = @dasm.sections.keys.grep(Integer).min rescue nil
-		@addr_max = @dasm.sections.map { |s, e| s + e.length }.max rescue nil
+		@addr_max = @dasm.sections.select { |s, _| s.kind_of?(Integer) }.map { |s, e| s + e.length }.max rescue nil
 		@raw_data_cache.clear
 		redraw
 	end


### PR DESCRIPTION
Hex view crashes when the base of a Section is not an Integer. For
instance, this happens with the dasm plugin selfmodify.rb, which creates
sections with base "smc#{VirtSections[dasm].length}".