### PR TITLE
 use stable sort to support ruby >= 2.5

### DIFF
--- a/metasm.gemspec
+++ b/metasm.gemspec
@@ -4,7 +4,7 @@ require 'metasm'
 
 Gem::Specification.new do |s|
   s.name          = 'metasm'
-  s.version       = '1.0.4'
+  s.version       = '1.0.5'
   s.summary       =
     "Metasm is a cross-architecture assembler, disassembler, linker, and debugger."
   s.description   = ""

--- a/metasm.gemspec
+++ b/metasm.gemspec
@@ -4,7 +4,7 @@ require 'metasm'
 
 Gem::Specification.new do |s|
   s.name          = 'metasm'
-  s.version       = '1.0.2'
+  s.version       = '1.0.4'
   s.summary       =
     "Metasm is a cross-architecture assembler, disassembler, linker, and debugger."
   s.description   = ""
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^tests/})
   s.require_paths = ["."]
   s.homepage      = 'http://metasm.cr0.org'
-  s.license       = 'LGPL'
+  s.license       = 'LGPL-2.1'
 
   s.add_development_dependency "bundler", "~> 1.7"
   s.add_development_dependency "rake"

--- a/metasm/gui/dasm_hex.rb
+++ b/metasm/gui/dasm_hex.rb
@@ -27,7 +27,7 @@ class HexWidget < DrawableWidget
 		@oldcaret_x_data = 42
 		@focus_zone = @oldfocus_zone = :hex
 		@addr_min = @dasm.sections.keys.grep(Integer).min rescue nil
-		@addr_max = @dasm.sections.map { |s, e| s + e.length }.max rescue nil
+		@addr_max = @dasm.sections.select { |s, _| s.kind_of?(Integer) }.map { |s, e| s + e.length }.max rescue nil
 		@view_addr = @dasm.prog_binding['entrypoint'] || @addr_min || 0
 		@show_address = @show_data = @show_ascii = true
 		@data_size = 1
@@ -538,7 +538,7 @@ class HexWidget < DrawableWidget
 
 	def gui_update
 		@addr_min = @dasm.sections.keys.grep(Integer).min rescue nil
-		@addr_max = @dasm.sections.map { |s, e| s + e.length }.max rescue nil
+		@addr_max = @dasm.sections.select { |s, _| s.kind_of?(Integer) }.map { |s, e| s + e.length }.max rescue nil
 		@raw_data_cache.clear
 		redraw
 	end


### PR DESCRIPTION
Due to changes in quicksort implementaions available in the
revised compiler for used for windows on ruby >= 2.5 we need
to ensure the sort it stable for intructions when selecting during
encode.