### PR TITLE
use the correct encoding for 'rep' on ia32/x86_64

### DIFF
--- a/metasm/cpu/ia32/encode.rb
+++ b/metasm/cpu/ia32/encode.rb
@@ -195,7 +195,7 @@ class Ia32
 			case k
 			when :jmp;  {:jmp => 0x3e, :nojmp => 0x2e}[v]
 			when :lock; 0xf0
-			when :rep;  {'repnz' => 0xf2, 'repz' => 0xf3, 'rep' => 0xf2}[v]
+			when :rep;  {'repnz' => 0xf2, 'repz' => 0xf3, 'rep' => 0xf3}[v]
 			when :jmphint; {'hintjmp' => 0x3e, 'hintnojmp' => 0x2e}[v]
 			when :seg; [0x26, 0x2E, 0x36, 0x3E, 0x64, 0x65][v.val]
 			end


### PR DESCRIPTION
While comparing the output of metasm to nasm, I noticed that the instruction `rep movsb` was encoded as `0xf2 0xa4` by metasm, which decodes to `repnz movsb`. This corrects the encoding for `rep`

https://c9x.me/x86/html/file_module_x86_id_279.html